### PR TITLE
Use flex on tags so they wrap properly

### DIFF
--- a/assets/css/blog/post.css
+++ b/assets/css/blog/post.css
@@ -81,10 +81,7 @@
 
 .post-tags .tag {
     font-weight: 700;
-}
-
-.post-tags .tag + .tag {
-    margin-left: 10px;
+    margin-right: 10px;
 }
 
 .post-tags .tag::before {

--- a/assets/css/blog/post.css
+++ b/assets/css/blog/post.css
@@ -75,6 +75,8 @@
 
 .post-tags {
     margin-top: 15px;
+    display: flex;
+    flex-wrap: wrap;
 }
 
 .post-tags .tag {


### PR DESCRIPTION
Not sure how to get the first tag element on the second row to not have a margin-left (it's not aligned properly because of this), but this is still an improvement. Otherwise, tags will wrap in the middle of words, looking broken.